### PR TITLE
update SQL to be parseable by more engines

### DIFF
--- a/mensor/measures/context.py
+++ b/mensor/measures/context.py
@@ -253,7 +253,7 @@ class Constraint(BaseConstraint):
             if spec.startswith('*/'):
                 generic = True
                 spec = spec[2:]
-            m = re.match(r'^([a-zA-Z0-9_/:]+)(=)(.*)$', spec)
+            m = re.match(r'^([a-zA-Z0-9_/:]+)([=|\>|\<|\>=|\<=])(.*)$', spec)
             if m is None:
                 raise ValueError('Constraint expression does not satisfy for "<field>=<value>".')
             return cls(*m.groups(), generic=generic)


### PR DESCRIPTION
### Summary
* Change WITH statements to subqueries 
    * Some engines (e.g. hive) do not support "recursive" WITH statements 
    *  May enable query engine to do more optimization (WITH statements are typically optimization blocks) 
* Name queries for better readability 
* Add additional filter relations and add to SQL provider 
  - not sure if this will work for non-constant filters 

### Testing Done
With the exception of https://github.com/airbnb/mensor/issues/7 this works on 
```
evaluate('impressions', 
   measures=['count'], 
   where=["ts>='2018-01-01'"], 
   segment_by=['page', 'user/country']
)
```