### PR TITLE
add prerender hook for implementing SQL providers

### DIFF
--- a/mensor/providers/sql.py
+++ b/mensor/providers/sql.py
@@ -174,9 +174,12 @@ class SQLMeasureProvider(MeasureProvider):
 
         return dims
 
+    def _prerender_sql(self, unit_type, measures=None, segment_by=None, where=None, joins=None, via=None, **opts):
+        return self.sql
+
     def _get_ir(self, unit_type, measures=None, segment_by=None, where=None, joins=None, via=None, **opts):
         sql = TEMPLATE.render(
-            base_sql=self.sql,
+            base_sql=self._prerender_sql(unit_type, measures, segment_by, where, joins, via, **opts),
             provider=self,
             dimensions=self._get_dimensions_sql(segment_by, joins),
             measures=self._get_measures_sql(measures, joins),


### PR DESCRIPTION
This PR adds a hook for implementing SQL measure providers to do a first pass render for the SQL depending on the parameters passed in to evaluate. This is because in some cases, the underlying SQL will itself be a template with parameters that should not be exposed to the end user. eg. 

```
sql = """
   SELECT id_transaction, value, ts  
     FROM mytransactiontable
     WHERE ts BETWEEN '{{ start_time }}' AND '{{ end_time }}' 
""" 
```