### PR TITLE
pass through attributes when creating metrics, dimensions, identifiers

### DIFF
--- a/mensor/measures/registry.py
+++ b/mensor/measures/registry.py
@@ -196,8 +196,14 @@ class MeasureRegistry(MeasureEvaluator):
                         mask = None
                         if kind in ('foreign_key', 'reverse_foreign_key') and avail_unit_type == feature.name:
                             mask = unit_type.name
+                        feature_attrs = feature.attrs
+                        feature_attrs.update({
+                            'unit_type': unit_type,
+                            'mask': mask,
+                            'kind': kind,
+                        })
                         features.append(
-                            _ResolvedFeature(feature.name, providers=[d.provider for d in instances], unit_type=unit_type, mask=mask, kind=kind)
+                            _ResolvedFeature(providers=[d.provider for d in instances], **feature_attrs)
                         )
         return features
 


### PR DESCRIPTION
### Summary
When configuring measures, I need to be able to configure additional properties, especially transforms. This change passes additional configuration up the chain. 

e,g, 

![image](https://user-images.githubusercontent.com/616139/44878825-c365d680-ac5c-11e8-9325-d7e6d4697497.png)

enables answering questions like ...

```
mensor_registry.evaluate('user', measures=['transfer/traders'], segment_by=['transfer/ds'])
```


### Testing Done
Manual