### PR TITLE
count measure should have its own distribution

### DIFF
--- a/mensor/backends/pandas.py
+++ b/mensor/backends/pandas.py
@@ -32,7 +32,7 @@ class PandasMeasureProvider(MutableMeasureProvider):
         self._data = data
         self._data_transform = data_transform
 
-        self.add_measure('count', shared=True, distribution=None, default=0)
+        self.add_measure('count', shared=True, distribution='count', default=0)
 
     @property
     def data(self):

--- a/mensor/measures/registries.py
+++ b/mensor/measures/registries.py
@@ -151,8 +151,17 @@ register_distn = global_stats_registry.distributions.register
 register_distn(
     name=None,
     stats=OrderedDict([
-        ('sum', 'sum'),
-        ('count', 'count')
+        ('raw', 'raw'),
+    ]),
+    scipy_class=None,
+    scipy_params=None
+)
+
+# Count distribution
+register_distn(
+    name='count',
+    stats=OrderedDict([
+        ('count', 'count'),
     ]),
     scipy_class=None,
     scipy_params=None


### PR DESCRIPTION
### Summary
Currently evaluating a provider for count measures & stats=False errors. e.g.

```
users.evaluate('user', measures=['count'], stats=False)
```


This patch seeks to address that by giving count measures a special distribution so that we can distinguish between count distributions (stats=True) and None distributions (stats=False) 

### Test Plan
manual