### PR TITLE
bugfix: count distribution should sum for rebase aggregations to work…

### DIFF
--- a/mensor/measures/registries.py
+++ b/mensor/measures/registries.py
@@ -161,7 +161,7 @@ register_distn(
 register_distn(
     name='count',
     stats=OrderedDict([
-        ('count', 'count'),
+        ('count', 'sum'),
     ]),
     scipy_class=None,
     scipy_params=None


### PR DESCRIPTION
... correctly 

e.g. `registry.evaluate('country', measures=['user/count'])`